### PR TITLE
RDS update 4.17: reduce pod count to 14 and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Templates for a DU workload deployed with [kube-burner](https://github.com/kube-
 
 | Pod | Number of Pods | Specs | Stress |
 |-----|----------------|-------| ------- |
-| Guaranteed | 1 pod | - 32 CPU, 1 GiB Memory, 16 GiB HP<br>- 2 configmaps and 4 secrets<br> 1 svc<br> | 32 threads of 100% CPU stress, 512mb vm stress |
-| BestEffort - web_server | 10 pods | - 100 mc CPU, 128 Mib Memory<br>- 2 configmaps and 4 secrets<br>- 10 svc<br> | Exposes 8080 port for probes|
-| BestEffort - curl_app | 10 pods | - 100 mc CPU, 128 Mib Memory<br>- Liveness Probes (every 10 secs)| Kubelet stress with probes, ~10-30% increase |
-| BestEffort - kubectl_pods | 10 pods | - 100 mc CPU , 128 Mib Memory<br>- kubectl get (every 1 sec) | Kube-api-server stress with kubectl get, ~50% increase |
+| Guaranteed | 1 pod | - 32 CPU, 1 GiB Memory, 16 GiB HP<br>- 2 configmaps and 4 secrets<br> 1 svc<br> | 32 threads of 100% CPU stress, 512M virtual memory stress |
+| BestEffort - web_server | 5 pods | - 100 mc CPU, 128 Mib Memory<br>- 2 configmaps and 4 secrets<br>- 10 svc<br> | Exposes 8080 port for probes |
+| BestEffort - curl_app | 5 pods | - 100 mc CPU, 128 Mib Memory<br>- Liveness Probes (every 10 secs)| Kubelet stress with probes, ~250 KB per sec n/w traffic on Primary CNI |
+| BestEffort - kubectl_pods | 5 pods | - 100 mc CPU , 128 Mib Memory<br>- kubectl get (every 1 sec) | Kube-api-server stress with kubectl get, ~10% increase due to workload |
 
-Intended for use in internal system testing pipelines but the templates can be run on any cluster supported by kube-burner
+Intended for use in internal system testing pipelines but the templates can be run on any cluster with kube-burner
 
 ### Steps to run workload with cpu_utilization tests:
 
@@ -18,4 +18,4 @@ Intended for use in internal system testing pipelines but the templates can be r
 
 ### Steps to run locally
 * export REGISTRY=quay.io/rh_ee_apalanis
-* Deploy DU workload with `kube-burner init --config du-intensive.yaml`
+* clone and deploy DU workload with `kube-burner init --config du-intensive.yaml`

--- a/du-intensive.yaml
+++ b/du-intensive.yaml
@@ -48,24 +48,24 @@ jobs:
 
     # Template of burstable pods with exec probes
       - objectTemplate: templates/webserver/webserver-deployment.yaml
-        replicas: 10
+        replicas: 5
         inputVars:
           Image: "{{ .REGISTRY }}/sampleapp"
       - objectTemplate: templates/webserver/webserver-service.yaml
-        replicas: 10
+        replicas: 5
       - objectTemplate: templates/webserver/curl-deployment.yaml
-        replicas: 10
+        replicas: 5
         inputVars:
           Image: "{{ .REGISTRY }}/curl"
 
     # Templates of burstable pods with kubeapiserver reqs
       - objectTemplate: templates/kubectlapp/serviceaccount.yaml
-        replicas: 10
+        replicas: 3
       - objectTemplate: templates/kubectlapp/role.yaml
-        replicas: 10
+        replicas: 3
       - objectTemplate: templates/kubectlapp/rolebinding.yaml
-        replicas: 10
+        replicas: 3
       - objectTemplate: templates/kubectlapp/deployment.yaml
-        replicas: 10
+        replicas: 3
         inputVars:
           Image: "{{ .REGISTRY }}/kubectl"


### PR DESCRIPTION
This MR includes the changes from 4.17 RDS review and feedback

Reduce kube api-server stress to 10% platform usage
Reduce kubelet traffic to <1 MB per sec on Primary CNI
Reduce total pod count to 14