### PR TITLE
Fix guaranteed pod annotations

### DIFF
--- a/templates/guaranteed/deployment.yaml
+++ b/templates/guaranteed/deployment.yaml
@@ -2,11 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: du-workload-{{.Replica}}
-  annotations:
-    # Disable CPU balance with CRIO
-    irq-load-balancing.crio.io: "disable"
-    cpu-load-balancing.crio.io: "disable"
-    cpu-quota.crio.io: "disable"
   labels:
     group: load
     svc: du-workload-{{.Replica}}
@@ -22,6 +17,11 @@ spec:
         group: load
         name: du-workload-{{.Replica}}
         redhat-best-practices-for-k8s.com/generic: target
+      annotations:
+        # Disable CPU balance with CRIO
+        irq-load-balancing.crio.io: "disable"
+        cpu-load-balancing.crio.io: "disable"
+        cpu-quota.crio.io: "disable"
     spec:
       runtimeClassName: performance-openshift-node-performance-profile
       containers:


### PR DESCRIPTION
Annotations should be at pod level, on spec.template.metadata, see doc [here](https://docs.openshift.com/container-platform/4.17/scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.html#cnf-scheduling-workload-onto-worker-with-real-time-capabilities_cnf-provisioning-low-latency)